### PR TITLE
Fix CSV ingestion and add coverage

### DIFF
--- a/src/ingest.py
+++ b/src/ingest.py
@@ -25,7 +25,7 @@ def init_db():
     count = cursor.fetchone()[0]
     if count == 0:
         try:
-            records = _load_vahan_records("data/vahan.csv")
+            records = list(_load_vahan_records("data/vahan.csv"))
             cursor.executemany(
                 """
                 INSERT INTO registrations (date, vehicle_category, maker, registrations)
@@ -67,12 +67,11 @@ def _load_vahan_records(path: str) -> Iterable[Tuple[str, str, str, int]]:
 
     The expected dataset contains columns: ``date``, ``vehicle_category``,
     ``maker`` and ``registrations``. Any rows missing these fields are
-    dropped. This helper relies on :func:`pandas.read_excel` which may
-    require the ``openpyxl`` dependency. If reading fails the caller
-    should handle the exception.
+    dropped. This helper uses :func:`pandas.read_csv` to load a CSV
+    dataset. If reading fails the caller should handle the exception.
     """
 
-    df = pd.read_excel(path)
+    df = pd.read_csv(path)
     df = df.dropna(subset=["date", "vehicle_category", "maker", "registrations"])
     df["date"] = pd.to_datetime(df["date"]).dt.strftime("%Y-%m-%d")
     df["registrations"] = pd.to_numeric(df["registrations"], errors="coerce").fillna(0).astype(int)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pandas as pd
+
+# Ensure src is importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.ingest import _load_vahan_records
+
+
+def test_load_vahan_records_csv(tmp_path):
+    df = pd.DataFrame({
+        "date": ["2025-01-01", "2025-02-01"],
+        "vehicle_category": ["2W", "4W"],
+        "maker": ["A", "B"],
+        "registrations": [100, 200],
+    })
+    csv_file = tmp_path / "sample.csv"
+    df.to_csv(csv_file, index=False)
+
+    records = list(_load_vahan_records(str(csv_file)))
+    assert records == [
+        ("2025-01-01", "2W", "A", 100),
+        ("2025-02-01", "4W", "B", 200),
+    ]


### PR DESCRIPTION
## Summary
- use pandas.read_csv for ingesting Vahan data
- ensure records are fully materialized so row count can be calculated
- add test covering CSV ingestion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a43e51b94832cafe1be36b6bf0ea5