### PR TITLE
Add sample 2024 data and handle missing YoY

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -112,17 +112,21 @@ if not cat_latest.empty:
         .round(2)
     )
     # Visualise YoY change per category for quick comparison
-    bar = (
-        alt.Chart(cat_latest)
-        .mark_bar()
-        .encode(
-            x=alt.X("vehicle_category:N", title="Category"),
-            y=alt.Y("yoy_pct:Q", title="YoY %"),
-            tooltip=["vehicle_category", alt.Tooltip("yoy_pct:Q", format=".2f")],
+    cat_yoy = cat_latest.dropna(subset=["yoy_pct"])
+    if not cat_yoy.empty:
+        bar = (
+            alt.Chart(cat_yoy)
+            .mark_bar()
+            .encode(
+                x=alt.X("vehicle_category:N", title="Category"),
+                y=alt.Y("yoy_pct:Q", title="YoY %"),
+                tooltip=["vehicle_category", alt.Tooltip("yoy_pct:Q", format=".2f")],
+            )
+            .properties(height=300)
         )
-        .properties(height=300)
-    )
-    st.altair_chart(bar, use_container_width=True)
+        st.altair_chart(bar, use_container_width=True)
+    else:
+        st.info("Not enough data for YoY comparison.")
 
 latest_q = cat_quarter["quarter"].max()
 cat_q_latest = cat_quarter[cat_quarter["quarter"] == latest_q]
@@ -189,22 +193,26 @@ if not lm.empty:
         .fillna("N/A")
         .round(2)
     )
-    mbar = (
-        alt.Chart(lm)
-        .mark_bar()
-        .encode(
-            x=alt.X("maker:N", title="Manufacturer"),
-            y=alt.Y("yoy_pct:Q", title="YoY %"),
-            color="vehicle_category:N",
-            tooltip=[
-                "maker",
-                "vehicle_category",
-                alt.Tooltip("yoy_pct:Q", format=".2f"),
-            ],
+    lm_yoy = lm.dropna(subset=["yoy_pct"])
+    if not lm_yoy.empty:
+        mbar = (
+            alt.Chart(lm_yoy)
+            .mark_bar()
+            .encode(
+                x=alt.X("maker:N", title="Manufacturer"),
+                y=alt.Y("yoy_pct:Q", title="YoY %"),
+                color="vehicle_category:N",
+                tooltip=[
+                    "maker",
+                    "vehicle_category",
+                    alt.Tooltip("yoy_pct:Q", format=".2f"),
+                ],
+            )
+            .properties(height=300)
         )
-        .properties(height=300)
-    )
-    st.altair_chart(mbar, use_container_width=True)
+        st.altair_chart(mbar, use_container_width=True)
+    else:
+        st.info("Not enough data for YoY comparison.")
 
 # Top manufacturers — QoQ
 st.subheader("Top manufacturers — QoQ (%) — latest quarter")

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -37,6 +37,16 @@ def init_db():
         except Exception:
             # Fallback to minimal sample data if dataset is missing
             sample_data = [
+                ("2024-01-01", "2W", "Honda", 1000),
+                ("2024-01-01", "4W", "Maruti", 1400),
+                ("2024-02-01", "2W", "Yamaha", 800),
+                ("2024-02-01", "4W", "Hyundai", 1200),
+                ("2024-03-01", "2W", "Honda", 1100),
+                ("2024-03-01", "4W", "Tata", 1000),
+                ("2024-04-01", "2W", "Suzuki", 900),
+                ("2024-04-01", "4W", "Maruti", 1500),
+                ("2024-05-01", "2W", "Honda", 1300),
+                ("2024-05-01", "4W", "Hyundai", 1100),
                 ("2025-01-01", "2W", "Honda", 1200),
                 ("2025-01-01", "4W", "Maruti", 1500),
                 ("2025-02-01", "2W", "Yamaha", 900),


### PR DESCRIPTION
## Summary
- Extend fallback ingestion data with 2024 records so YoY calculations have a prior-year baseline.
- Guard Streamlit charts against missing YoY values, showing a helpful message instead of a flat line.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689af491c160832c835e4f9728509fd0