### PR TITLE
feat: add month-over-month insight

### DIFF
--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -28,10 +28,6 @@ def get_key_insight(df: pd.DataFrame) -> str:
     latest_total = df[df["period"] == latest_period]["registrations"].sum()
     prev_total = df[df["period"] == prev_year_period]["registrations"].sum()
 
-    yoy_growth = (
-        (latest_total - prev_total) / prev_total * 100 if prev_total else float("nan")
-    )
-
     top_category = (
         df[df["period"] == latest_period]
         .groupby(category_col)["registrations"]
@@ -39,8 +35,22 @@ def get_key_insight(df: pd.DataFrame) -> str:
         .idxmax()
     )
 
-    growth_str = f"{yoy_growth:.2f}%" if pd.notnull(yoy_growth) else "N/A"
-    return (
-        f"Year-over-year growth is {growth_str} with {top_category} leading the registrations."
-    )
+    if prev_total:
+        yoy_growth = (latest_total - prev_total) / prev_total * 100
+        growth_str = f"{yoy_growth:.2f}%"
+        metric = "Year-over-year"
+    else:
+        prev_month_period = latest_period - pd.DateOffset(months=1)
+        prev_month_total = (
+            df[df["period"] == prev_month_period]["registrations"].sum()
+        )
+        mom_growth = (
+            (latest_total - prev_month_total) / prev_month_total * 100
+            if prev_month_total
+            else float("nan")
+        )
+        growth_str = f"{mom_growth:.2f}%" if pd.notnull(mom_growth) else "N/A"
+        metric = "Month-over-month"
+
+    return f"{metric} growth is {growth_str} with {top_category} leading the registrations."
 

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import pandas as pd
+
+# Ensure src is importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.data_processing import get_key_insight
+
+
+def test_get_key_insight_month_over_month():
+    df = pd.DataFrame({
+        "date": ["2024-03-01", "2024-04-01"],
+        "vehicle_category": ["2W", "2W"],
+        "registrations": [100, 150],
+    })
+
+    result = get_key_insight(df)
+    assert "Month-over-month" in result
+    assert "50.00%" in result
+


### PR DESCRIPTION
## Summary
- support month-over-month fallback when year-over-year data is missing
- add test for month-over-month growth calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689af751a5d4832cae5302f0e3486e38