### PR TITLE
Handle YoY calculations with missing months

### DIFF
--- a/src/transform.py
+++ b/src/transform.py
@@ -31,10 +31,23 @@ def compute_yoy_qoq(df: pd.DataFrame):
         .sort_values(["maker", "vehicle_category", "period"])
     )
 
-    # Year over year percentage change
-    monthly["registrations_prev_year"] = (
-        monthly.groupby(["maker", "vehicle_category"])["registrations"].shift(12)
+    # Year over year percentage change.
+    # Using ``shift(12)`` assumes there are 12 consecutive monthly rows for each
+    # maker/category combination.  The dataset in this project can have missing
+    # months which would result in NaNs even when there is data for the same
+    # month in the previous year.  To make the calculation robust we instead
+    # align each row with the matching period from the previous year using a
+    # merge on the shifted period.
+
+    prev_year = monthly[["maker", "vehicle_category", "period", "registrations"]].copy()
+    prev_year["period"] = prev_year["period"] + pd.DateOffset(years=1)
+    prev_year = prev_year.rename(columns={"registrations": "registrations_prev_year"})
+    monthly = monthly.merge(
+        prev_year,
+        on=["maker", "vehicle_category", "period"],
+        how="left",
     )
+    monthly = monthly.sort_values(["maker", "vehicle_category", "period"])
     monthly["yoy_pct"] = (
         (monthly["registrations"] - monthly["registrations_prev_year"]) / monthly["registrations_prev_year"]
         * 100
@@ -85,7 +98,16 @@ def compute_category_growth(df: pd.DataFrame):
         .sort_values(["vehicle_category", "period"])
     )
     monthly["quarter"] = monthly["period"].dt.to_period("Q").dt.to_timestamp()
-    monthly["prev_year_regs"] = monthly.groupby("vehicle_category")["registrations"].shift(12)
+
+    # Similar to ``compute_yoy_qoq`` we avoid ``shift(12)`` to handle missing
+    # months.  We join on the period offset by one year which ensures that a
+    # YoY value is produced whenever data for the same month in the previous
+    # year exists, even if intermediate months are absent.
+    prev_year = monthly[["vehicle_category", "period", "registrations"]].copy()
+    prev_year["period"] = prev_year["period"] + pd.DateOffset(years=1)
+    prev_year = prev_year.rename(columns={"registrations": "prev_year_regs"})
+    monthly = monthly.merge(prev_year, on=["vehicle_category", "period"], how="left")
+    monthly = monthly.sort_values(["vehicle_category", "period"])
     monthly["yoy_pct"] = (
         (monthly["registrations"] - monthly["prev_year_regs"]) / monthly["prev_year_regs"] * 100
     ).where(monthly["prev_year_regs"].ne(0))

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,27 @@
+import pandas as pd
+from src.transform import compute_yoy_qoq, compute_category_growth
+
+
+def test_compute_yoy_qoq_missing_months():
+    """YoY should be computed even if intermediate months are absent."""
+    df = pd.DataFrame({
+        "date": ["2022-01-15", "2023-01-20"],
+        "vehicle_category": ["Car", "Car"],
+        "maker": ["A", "A"],
+        "registrations": [100, 200],
+    })
+    monthly, _ = compute_yoy_qoq(df)
+    res = monthly[monthly["period"] == pd.Timestamp("2023-01-01")]
+    assert res["yoy_pct"].iloc[0] == 100.0
+
+
+def test_compute_category_growth_missing_months():
+    """Category YoY should be calculated when same month previous year exists."""
+    df = pd.DataFrame({
+        "date": ["2022-01-01", "2023-01-01"],
+        "vehicle_category": ["Two-Wheeler", "Two-Wheeler"],
+        "registrations": [50, 75],
+    })
+    monthly, _ = compute_category_growth(df)
+    res = monthly[monthly["period"] == pd.Timestamp("2023-01-01")]
+    assert res["yoy_pct"].iloc[0] == 50.0


### PR DESCRIPTION
## Summary
- make year-over-year computation robust to missing monthly data
- calculate category YoY using period-based merge
- test YoY calculations for sparse monthly inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dabda391c832cad48f818f6d3904f