### PR TITLE
Handle single date from st.date_input

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -64,8 +64,10 @@ with st.sidebar:
         max_value=max_date
     )
 
-    if isinstance(date_range, tuple):
-        start_date, end_date = date_range
+    # st.date_input can return a single date or a list/tuple of dates
+    if isinstance(date_range, (list, tuple)):
+        start_date = date_range[0]
+        end_date = date_range[-1] if len(date_range) > 1 else max_date
     else:
         start_date, end_date = date_range, max_date
 


### PR DESCRIPTION
## Summary
- Avoid ValueError by accepting single or range values from `st.date_input` and defaulting to maximum date for missing end date

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e0db331d0832c99e51b726b5b39d8